### PR TITLE
Handle the new token data & remove force redirect

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+* The authentication flow now works in both popup and redirect modes.
 
 ------------------
 ## [2.0.2] - 2026-02-25

--- a/src/AJAX.php
+++ b/src/AJAX.php
@@ -82,12 +82,16 @@ class AJAX {
 
 		$guest        = 0;
 		$current_user = get_current_user_id();
+		$tokens       = array(
+			'id_token' => $id_token,
+		);
+
 		if ( $guest === $current_user ) {
-			$this->user->sign_in_user( $user_id, array( 'id_token' => $id_token ) );
+			$this->user->sign_in_user( $user_id, $tokens );
 		} else {
 			// The only condition for displaying the sign-in button is that the user does not have an access token.
 			// Therefore, it could be displayed for a signed-in user. If the user is already signed in, we only update the tokens.
-			$this->user->set_tokens( $user_id, array( 'id_token' => $id_token ) );
+			$this->user->set_tokens( $user_id, $tokens );
 		}
 
 		// phpcs:ignore -- Nonce is checked by calling function.

--- a/src/AJAX.php
+++ b/src/AJAX.php
@@ -85,7 +85,7 @@ class AJAX {
 		if ( $guest === $current_user ) {
 			$this->user->sign_in_user( $user_id, array( 'id_token' => $id_token ) );
 		} else {
-			// The only condition for displaying the sign-in button is that the user does not have a refresh token.
+			// The only condition for displaying the sign-in button is that the user does not have an access token.
 			// Therefore, it could be displayed for a signed-in user. If the user is already signed in, we only update the tokens.
 			$this->user->set_tokens( $user_id, array( 'id_token' => $id_token ) );
 		}

--- a/src/AJAX.php
+++ b/src/AJAX.php
@@ -63,6 +63,11 @@ class AJAX {
 
 		$id_token = sanitize_text_field( wp_unslash( $id_token ) );
 		$payload  = $this->jwt->get_payload( $id_token );
+
+		if ( is_wp_error( $payload ) ) {
+			wp_send_json_error( $payload->get_error_message() );
+		}
+
 		$userdata = $this->user->get_user_data( $payload );
 
 		if ( username_exists( $userdata['user_login'] ) || email_exists( $userdata['user_email'] ) ) {

--- a/src/AJAX.php
+++ b/src/AJAX.php
@@ -89,7 +89,7 @@ class AJAX {
 		if ( $guest === $current_user ) {
 			$this->user->sign_in_user( $user_id, $tokens );
 		} else {
-			// The only condition for displaying the sign-in button is that the user does not have an access token.
+			// The only condition for displaying the sign-in button is that the user does not have an id token.
 			// Therefore, it could be displayed for a signed-in user. If the user is already signed in, we only update the tokens.
 			$this->user->set_tokens( $user_id, $tokens );
 		}

--- a/src/AJAX.php
+++ b/src/AJAX.php
@@ -56,24 +56,14 @@ class AJAX {
 	 */
 	private function handle_sign_in() {
 		// phpcs:ignore -- Nonce is checked by calling function.
-		$refresh_token = wc_get_var( $_POST['refresh_token'] );
-		if ( empty( $refresh_token ) ) {
+		$id_token = wc_get_var( $_POST['id_token'] );
+		if ( empty( $id_token ) ) {
 			wp_send_json_error( 'missing parameters' );
 		}
 
-		$refresh_token = sanitize_text_field( wp_unslash( $refresh_token ) );
-		$tokens        = $this->jwt->get_tokens( $refresh_token );
-		if ( is_wp_error( $tokens ) ) {
-			$error_message = $tokens->get_error_message();
-			if ( is_array( $error_message ) ) {
-				$error_message = implode( $error_message );
-			}
-
-			wp_send_json_error( 'could not retrieve tokens: ' . $error_message );
-		}
-
-		$id_token = $this->jwt->get_payload( $tokens['id_token'] );
-		$userdata = $this->user->get_user_data( $id_token );
+		$id_token = sanitize_text_field( wp_unslash( $id_token ) );
+		$payload  = $this->jwt->get_payload( $id_token );
+		$userdata = $this->user->get_user_data( $payload );
 
 		if ( username_exists( $userdata['user_login'] ) || email_exists( $userdata['user_email'] ) ) {
 			$user_id = $this->user->merge_with_existing_user( $userdata );
@@ -88,11 +78,11 @@ class AJAX {
 		$guest        = 0;
 		$current_user = get_current_user_id();
 		if ( $guest === $current_user ) {
-			$this->user->sign_in_user( $user_id, $tokens );
+			$this->user->sign_in_user( $user_id, array( 'id_token' => $id_token ) );
 		} else {
 			// The only condition for displaying the sign-in button is that the user does not have a refresh token.
 			// Therefore, it could be displayed for a signed-in user. If the user is already signed in, we only update the tokens.
-			$this->user->set_tokens( $user_id, $tokens );
+			$this->user->set_tokens( $user_id, array( 'id_token' => $id_token ) );
 		}
 
 		// phpcs:ignore -- Nonce is checked by calling function.

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -125,49 +125,4 @@ class JWT {
 		$jwt_token = $this->is_valid_jwt( $jwt_token );
 		return empty( $jwt_token ) ? new \WP_Error( 'JWT token invalid.' ) : $jwt_token;
 	}
-
-	/**
-	 * Retrieve tokens from Klarna.
-	 *
-	 * @param string $refresh_token The Klarna refresh token.
-	 * @return array|\WP_Error A validated array of tokens or WP_Error if the no new tokens could be retrieved.
-	 */
-	public function get_tokens( $refresh_token ) {
-		// We need an existing refresh token to issue a new one.
-		if ( empty( $refresh_token ) ) {
-			return new \WP_Error( 'missing_refresh_token', 'No refresh token provided.' );
-		}
-
-		// We retrieve the client ID from the settings. This should ensure that a refresh token is only used for the correct client.
-		$response = wp_remote_post(
-			"{$this->base_url}/{$this->region}/lp/idp/oauth2/token",
-			array(
-				'headers' => array(
-					'Content-Type' => 'application/x-www-form-urlencoded',
-				),
-				'body'    => array(
-					'refresh_token' => $refresh_token,
-					'client_id'     => $this->settings->get( 'client_id' ),
-					'grant_type'    => 'refresh_token',
-				),
-			)
-		);
-
-		$code = wp_remote_retrieve_response_code( $response );
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		} elseif ( $code >= 400 ) {
-			return new \WP_Error( 'refresh_token', wp_remote_retrieve_body( $response ) );
-		}
-
-		// Validate and extract the JWT tokens.
-		$tokens = json_decode( wp_remote_retrieve_body( $response ), true );
-		if ( ! $this->is_valid_jwt( $tokens['id_token'] ) ) {
-			return new \WP_Error( 'invalid_jwt', 'The response from Klarna was not a valid JWT.' );
-		}
-
-		// convert to milliseconds from seconds.
-		$tokens['expires_in'] = $tokens['expires_in'] * 1000 + time();
-		return $tokens;
-	}
 }

--- a/src/SignInWithKlarna.php
+++ b/src/SignInWithKlarna.php
@@ -210,7 +210,7 @@ class SignInWithKlarna {
 		 * Check if we need to display the SIWK button:
 		 * 1. If SIWK is enabled.
 		 * 2. if logged in or guest but has not signed in with klarna.
-		 * 3. signed in, but need to renew the refresh token.
+		 * 3. signed in, but need to renew the access token.
 		 */
 
 		$kp_unavailable_feature_ids = get_option( 'kp_unavailable_feature_ids', array() );
@@ -224,6 +224,6 @@ class SignInWithKlarna {
 		}
 
 		$tokens = get_user_meta( get_current_user_id(), User::TOKENS_KEY, true );
-		return ! isset( $tokens['refresh_token'] );
+		return ! isset( $tokens['access_token'] );
 	}
 }

--- a/src/SignInWithKlarna.php
+++ b/src/SignInWithKlarna.php
@@ -210,7 +210,7 @@ class SignInWithKlarna {
 		 * Check if we need to display the SIWK button:
 		 * 1. If SIWK is enabled.
 		 * 2. if logged in or guest but has not signed in with klarna.
-		 * 3. signed in, but need to renew the access token.
+		 * 3. Signed in, but has not completed SIWK authentication for this account.
 		 */
 
 		$kp_unavailable_feature_ids = get_option( 'kp_unavailable_feature_ids', array() );
@@ -224,6 +224,6 @@ class SignInWithKlarna {
 		}
 
 		$tokens = get_user_meta( get_current_user_id(), User::TOKENS_KEY, true );
-		return ! isset( $tokens['access_token'] );
+		return ! isset( $tokens['id_token'] );
 	}
 }

--- a/src/User.php
+++ b/src/User.php
@@ -55,32 +55,15 @@ class User {
 
 		// We do not have to "validate the access token before using it", but we must check if it has expired. We subtract 30 seconds as a buffer.
 		$has_expired = time() > ( $tokens['expires_in'] - 30_000 );
-		if ( ! $has_expired ) {
-			return $tokens['access_token'];
-		}
-
-		// Check if the user has refresh token.
-		$refresh_token = $tokens['refresh_token'] ?? false;
-		if ( empty( $refresh_token ) ) {
+		if ( $has_expired ) {
 			return false;
 		}
 
-		// Update refresh token, and fetch new access token.
-		$new_tokens = $this->jwt->get_tokens( $refresh_token );
-		if ( ! is_wp_error( $new_tokens ) ) {
-			$this->set_tokens( $user_id, $new_tokens );
-			return $new_tokens['access_token'];
-		}
-
-		// Mostly likely the merchant changed environment.
-		// Delete the user meta to ensure a new refresh token is issued next time in the new environment, and to make the SIWK button appear again on the frontend.
-		unset( $tokens['refresh_token'] );
-		update_user_meta( $user_id, self::TOKENS_KEY, $tokens );
-		return false;
+		return $tokens['access_token'];
 	}
 
 	/**
-	 * Store the Klarna tokens retrieved from the "refresh token" request to the user's metadata.
+	 * Store the Klarna tokens in the user's metadata.
 	 *
 	 * @param int   $user_id The Woo user ID.
 	 * @param array $tokens Klarna tokens.

--- a/src/assets/js/siwk.js
+++ b/src/assets/js/siwk.js
@@ -23,8 +23,6 @@ const siwk = {
             theme: siwk.params.theme,
             shape: siwk.params.shape,
             alignment: siwk.params.alignment,
-            initiationMode: 'REDIRECT',
-            interactionMode: 'REDIRECT',
         });
 
         // Only mount and register the events if the buttonWrapper exists.
@@ -39,17 +37,14 @@ const siwk = {
     },
 
     onSignin: async function (response) {
-        const { user_account_linking } = response
-        const { user_account_linking_id_token: id_token, user_account_linking_refresh_token: refresh_token } =
-            user_account_linking
+        const { idToken } = response
 
         jQuery.ajax({
             type: "POST",
             url: siwk.params.sign_in_from_popup_url,
             data: {
                 url: window.location.href,
-                id_token,
-                refresh_token,
+                id_token: idToken,
                 nonce: siwk.params.sign_in_from_popup_nonce,
             },
             success: (data) => {

--- a/src/templates/callback.html
+++ b/src/templates/callback.html
@@ -9,14 +9,11 @@
     <script type="text/javascript">
       window.KlarnaSDKCallback = function (klarna) {
         klarna.Identity.on("signin", async (response) => {
-          const { user_account_linking } = response;
-          const {
-            user_account_linking_id_token: id_token,
-          } = user_account_linking;
+          const { idToken } = response
 
           // admin-ajax.php doesn't support JSON request. We need to use FormData.
           const formData = new FormData();
-          formData.append("id_token", id_token);
+          formData.append("id_token", idToken);
 
           fetch("%sign_in_url%", {
             method: "POST",

--- a/src/templates/callback.html
+++ b/src/templates/callback.html
@@ -2,7 +2,7 @@
   <head>
     <script
       defer
-      src="https://js.klarna.com/web-sdk/v1/klarna.js"
+      src="https://js.klarna.com/web-sdk/v2/klarna.js"
       data-client-id="%client_id%"
       data-locale="%locale%"
     ></script>

--- a/src/templates/callback.html
+++ b/src/templates/callback.html
@@ -12,13 +12,11 @@
           const { user_account_linking } = response;
           const {
             user_account_linking_id_token: id_token,
-            user_account_linking_refresh_token: refresh_token,
           } = user_account_linking;
 
           // admin-ajax.php doesn't support JSON request. We need to use FormData.
           const formData = new FormData();
           formData.append("id_token", id_token);
-          formData.append("refresh_token", refresh_token);
 
           fetch("%sign_in_url%", {
             method: "POST",


### PR DESCRIPTION
**Question:** This seems log in the user correctly and retrieve all needed address/name data etc. Removing the `interactionMode: 'REDIRECT'` does result in the login redirect being handled differently though; as I'm redirected to the cart page instead of the shop page?