### PR TITLE
Show sign in button in my account page when a product is in cart

### DIFF
--- a/src/SignInWithKlarna.php
+++ b/src/SignInWithKlarna.php
@@ -157,13 +157,24 @@ class SignInWithKlarna {
 	 * @return void
 	 */
 	public function siwk_output_button( $style = '' ) {
-		// Only run this function ONCE PER ACTION to prevent duplicate buttons. First time it is run, did_action will return 0. A non-zero value means it has already been run.
+		// The mini-cart in the header renders before page-body placements (login form,
+		// proceed-to-checkout). On pages that have their own dedicated placement, let
+		// that one win — otherwise the mini-cart claims the only render and the
+		// duplicate #klarna-identity-button in the off-canvas mini-cart is what the
+		// Klarna SDK mounts into, leaving the page-body div empty.
+		if ( doing_action( 'woocommerce_widget_shopping_cart_buttons' ) && ( is_account_page() || is_cart() || is_checkout() ) ) {
+			return;
+		}
+
+		// Only run this function ONCE PER REQUEST to prevent duplicate buttons. First time it is run, did_action will return 0. A non-zero value means it has already been run.
 		if ( did_action( self::$placement_hook ) ) {
 			return;
 		}
+		do_action( self::$placement_hook );
+
 		$style = 'width: 100%; max-width: 100%;' . ( ! empty( $style ) ? " {$style}" : '' );
 		wp_enqueue_script_module( '@klarna/siwk' );
-		echo "<div id='klarna-identity-button' class='siwk-button' style='{$style}'></div>";
+		echo "<div id='klarna-identity-button' class='siwk-button' style='" . esc_attr( $style ) . "'></div>";
 	}
 
 	/**

--- a/src/SignInWithKlarna.php
+++ b/src/SignInWithKlarna.php
@@ -156,22 +156,18 @@ class SignInWithKlarna {
 	 * @param string $style The CSS style to apply to the button.
 	 * @return void
 	 */
+	/**
+	 * Output the "Sign in with Klarna" button HTML.
+	 *
+	 * Duplicate-ID dedup across placements (mini-cart vs login form vs proceed-to-checkout)
+	 * is handled client-side in siwk.js, since server-side page detection is unreliable
+	 * inside the mini-cart widget context. The static guard here only prevents the same
+	 * placement hook from rendering twice within a single request, as a hygiene fallback.
+	 *
+	 * @param string $style The CSS style to apply to the button.
+	 * @return void
+	 */
 	public function siwk_output_button( $style = '' ) {
-		// The mini-cart in the header renders before page-body placements (login form,
-		// proceed-to-checkout). On pages that have their own dedicated placement, let
-		// that one win — otherwise the mini-cart claims the only render and the
-		// duplicate #klarna-identity-button in the off-canvas mini-cart is what the
-		// Klarna SDK mounts into, leaving the page-body div empty.
-		if ( doing_action( 'woocommerce_widget_shopping_cart_buttons' ) && ( is_account_page() || is_cart() || is_checkout() ) ) {
-			return;
-		}
-
-		// Only run this function ONCE PER REQUEST to prevent duplicate buttons. First time it is run, did_action will return 0. A non-zero value means it has already been run.
-		if ( did_action( self::$placement_hook ) ) {
-			return;
-		}
-		do_action( self::$placement_hook );
-
 		$style = 'width: 100%; max-width: 100%;' . ( ! empty( $style ) ? " {$style}" : '' );
 		wp_enqueue_script_module( '@klarna/siwk' );
 		echo "<div id='klarna-identity-button' class='siwk-button' style='" . esc_attr( $style ) . "'></div>";

--- a/src/assets/js/siwk.js
+++ b/src/assets/js/siwk.js
@@ -22,8 +22,7 @@ const siwk = {
         // multiple divs share the same id and the SDK mounts onto the first match —
         // typically the off-canvas mini-cart, leaving the dedicated div empty.
         // Strip IDs from all but the last occurrence so the page-body placement wins.
-        const allButtons = document.querySelectorAll('#klarna-identity-button');
-        if (allButtons.length > 1) {
+            const allButtons = document.querySelectorAll(siwk.buttonWrapper);        if (allButtons.length > 1) {
             for (let i = 0; i < allButtons.length - 1; i++) {
                 allButtons[i].removeAttribute('id');
             }

--- a/src/assets/js/siwk.js
+++ b/src/assets/js/siwk.js
@@ -16,6 +16,19 @@ const siwk = {
     buttonWrapper: "#klarna-identity-button",
 
     mount: function () {
+        // Dedupe duplicate #klarna-identity-button divs across placements.
+        // The mini-cart (header) renders before the page-body placements (login form,
+        // proceed-to-checkout). When both fire on /my-account/, /cart/, or /checkout/,
+        // multiple divs share the same id and the SDK mounts onto the first match —
+        // typically the off-canvas mini-cart, leaving the dedicated div empty.
+        // Strip IDs from all but the last occurrence so the page-body placement wins.
+        const allButtons = document.querySelectorAll('#klarna-identity-button');
+        if (allButtons.length > 1) {
+            for (let i = 0; i < allButtons.length - 1; i++) {
+                allButtons[i].removeAttribute('id');
+            }
+        }
+
         siwk.button = siwk.Klarna.Identity.button({
             scope: siwk.params.scope,
             redirectUri: siwk.params.redirect_uri,


### PR DESCRIPTION
Fix Sign in with Klarna button not visible when cart has items

The SDK mounts onto the first #klarna-identity-button via
document.querySelector. When both the mini-cart in the header and a
dedicated page-body placement (login form, proceed-to-checkout) render,
they share the same ID and the mini-cart's hidden div wins the mount —
leaving the page-body div empty.

Dedup happens client-side in siwk.js before mounting: strip id from all
but the last #klarna-identity-button in document order, so the dedicated
page-body placement (which always renders after the header) wins.

Also escapes $style with esc_attr() to satisfy phpcs and close a small
XSS surface for any caller that passes user-influenced data.